### PR TITLE
fix: remove redundant console.log

### DIFF
--- a/src/lib/authorizeViaCli.ts
+++ b/src/lib/authorizeViaCli.ts
@@ -63,8 +63,7 @@ const authorizeViaCli = async () => {
 
         process.exit(0);
       } catch (error) {
-        console.log(error);
-        console.log(chalk.redBright(error));
+        console.error(chalk.redBright(error));
         process.exit(1);
       }
     });


### PR DESCRIPTION
Remove the redundant `console.log` and write the error to stderr instead of stdout